### PR TITLE
[FIX] demo link in README_zh.md invalid

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -69,7 +69,7 @@ Choerodon微服务开发框架有两个方面，即 **微服务后端**和 **前
 
 ## 演示环境
 
-您还可以体验Choerodon的[演示环境](https://api.choerodon.com.cn/oauth/login)。
+您还可以体验Choerodon的[演示环境](https://choerodon.com.cn/#/iam/register-organization)。
 
 ## 参与贡献
 


### PR DESCRIPTION
The link `https://api.choerodon.com.cn/oauth/login` URL in README_zh.md is invalid,  use the correct link to replace it.